### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We're using [`composer/composer`](https://github.com/composer/composer) to manag
 
 ## Coding Standard
 
-This project uses [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) to enforce coding standards.
+This project uses [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) to enforce coding standards.
 The coding standard rules are defined in the **phpcs.xml.dist** file (part of this repository).
 
 Your Pull-Request must be compliant with the said standard.


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932